### PR TITLE
Implement merge_ts in python

### DIFF
--- a/merge_ts/merge_ts.py
+++ b/merge_ts/merge_ts.py
@@ -38,16 +38,17 @@ def merge_ts(
     ],
 ):
     """Merge XYTS files."""
+
     component_xyts_files = sorted(
         [
-            xyts.XYTSFile(xyts_file_path, proc_local_file=True, no_gp=True)
+            xyts.XYTSFile(
+                xyts_file_path, proc_local_file=True, meta_only=True, round_dt=False
+            )
             for xyts_file_path in component_xyts_filepaths
         ],
         key=lambda xyts_file: (xyts_file.y0, xyts_file.x0),
     )
-
     top_left = component_xyts_files[0]
-
     merged_ny = top_left.ny
     merged_nt = top_left.nt
 
@@ -60,6 +61,7 @@ def merge_ts(
         os.lseek(xyts_file_descriptor, xyts_proc_header_size, os.SEEK_SET)
         xyts_file_descriptors.append(xyts_file_descriptor)
 
+    # If output doesn't exist when we os.open it, we'll get an error.
     output.touch()
     merged_fd = os.open(output, os.O_WRONLY)
 
@@ -80,9 +82,7 @@ def merge_ts(
         + top_left.mlat.tobytes()
         + top_left.mlon.tobytes()
     )
-
     os.write(merged_fd, xyts_header)
-
     merge_ts_loop.merge_fds(
         merged_fd,
         xyts_file_descriptors,

--- a/merge_ts/merge_ts.py
+++ b/merge_ts/merge_ts.py
@@ -16,12 +16,13 @@ import os
 from pathlib import Path
 from typing import Annotated
 
-import merge_ts_loop
 import typer
 from qcore import xyts
 
+from merge_ts import merge_ts_loop
 
-def main(
+
+def merge_ts(
     component_xyts_filepaths: Annotated[
         list[Path],
         typer.Argument(
@@ -98,5 +99,11 @@ def main(
     os.close(merged_fd)
 
 
+# The following function is here to define an entrypoint for the setup.py file.
+def main():
+    """Main script entrypoint."""
+    typer.run(merge_ts)
+
+
 if __name__ == "__main__":
-    typer.run(main)
+    main()

--- a/merge_ts/merge_ts.py
+++ b/merge_ts/merge_ts.py
@@ -23,19 +23,23 @@ from merge_ts import merge_ts_loop
 
 
 def merge_ts(
-    component_xyts_filepaths: Annotated[
-        list[Path],
+    component_xyts_directory: Annotated[
+        Path,
         typer.Argument(
-            help="The input xyts files to merge",
-            dir_okay=False,
+            help="The input xyts directory containing files to merge",
+            dir_okay=True,
+            file_okay=False,
             exists=True,
             readable=True,
         ),
     ],
     output: Annotated[
         Path,
-        typer.Option(help="The output xyts file", dir_okay=False, writable=True),
+        typer.Argument(help="The output xyts file", dir_okay=False, writable=True),
     ],
+    glob_pattern: Annotated[
+        str, typer.Option(help="Set a custom glob pattern for merging the xyts files")
+    ] = "*xyts-*.e3d",
 ):
     """Merge XYTS files."""
 
@@ -44,7 +48,7 @@ def merge_ts(
             xyts.XYTSFile(
                 xyts_file_path, proc_local_file=True, meta_only=True, round_dt=False
             )
-            for xyts_file_path in component_xyts_filepaths
+            for xyts_file_path in component_xyts_directory.glob(glob_pattern)
         ],
         key=lambda xyts_file: (xyts_file.y0, xyts_file.x0),
     )

--- a/merge_ts/merge_ts.py
+++ b/merge_ts/merge_ts.py
@@ -14,10 +14,10 @@ Note:
 """
 import os
 from pathlib import Path
-from typing import Annotated
 
 import typer
 from qcore import xyts
+from typing_extensions import Annotated
 
 from merge_ts import merge_ts_loop
 

--- a/merge_ts/merge_ts.py
+++ b/merge_ts/merge_ts.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Module for merging XYTS files.
+
+This module provides functionality for merging XYTS files. It takes multiple
+input XYTS files, representing small patches of a larger simulation domain, and
+merges them into one large output.
+
+$ python merge_ts.py input1.e3d input2.e3d -o output.xyts
+
+Note:
+    This module assumes the input XYTS files have the same temporal dimensions
+    (i.e. nt is constant).
+"""
+import os
+from pathlib import Path
+from typing import Annotated
+
+import merge_ts_loop
+import typer
+from qcore import xyts
+
+
+def main(
+    component_xyts_filepaths: Annotated[
+        list[Path],
+        typer.Argument(
+            help="The input xyts files to merge",
+            dir_okay=False,
+            exists=True,
+            readable=True,
+        ),
+    ],
+    output: Annotated[
+        Path,
+        typer.Option(help="The output xyts file", dir_okay=False, writable=True),
+    ],
+):
+    """Merge XYTS files."""
+    component_xyts_files = sorted(
+        [
+            xyts.XYTSFile(xyts_file_path, proc_local_file=True, no_gp=True)
+            for xyts_file_path in component_xyts_filepaths
+        ],
+        key=lambda xyts_file: (xyts_file.y0, xyts_file.x0),
+    )
+
+    top_left = component_xyts_files[0]
+
+    merged_ny = top_left.ny
+    merged_nt = top_left.nt
+
+    xyts_proc_header_size = 72
+
+    xyts_file_descriptors = []
+    for xyts_file in component_xyts_files:
+        xyts_file_descriptor = os.open(xyts_file.xyts_path, os.O_RDONLY)
+        # Skip the header for each file descriptor
+        os.lseek(xyts_file_descriptor, xyts_proc_header_size, os.SEEK_SET)
+        xyts_file_descriptors.append(xyts_file_descriptor)
+
+    output.touch()
+    merged_fd = os.open(output, os.O_WRONLY)
+
+    xyts_header = (
+        top_left.x0.tobytes()
+        + top_left.y0.tobytes()
+        + top_left.z0.tobytes()
+        + top_left.t0.tobytes()
+        + top_left.nx.tobytes()
+        + top_left.ny.tobytes()
+        + top_left.nz.tobytes()
+        + top_left.nt.tobytes()
+        + top_left.dx.tobytes()
+        + top_left.dy.tobytes()
+        + top_left.hh.tobytes()
+        + top_left.dt.tobytes()
+        + top_left.mrot.tobytes()
+        + top_left.mlat.tobytes()
+        + top_left.mlon.tobytes()
+    )
+
+    os.write(merged_fd, xyts_header)
+
+    merge_ts_loop.merge_fds(
+        merged_fd,
+        xyts_file_descriptors,
+        merged_nt,
+        merged_ny,
+        [f.local_nx for f in component_xyts_files],
+        [f.local_ny for f in component_xyts_files],
+        [f.y0 for f in component_xyts_files],
+    )
+
+    for xyts_file_descriptor in xyts_file_descriptors:
+        os.close(xyts_file_descriptor)
+
+    os.close(merged_fd)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/merge_ts/merge_ts_loop.pyx
+++ b/merge_ts/merge_ts_loop.pyx
@@ -1,0 +1,52 @@
+import os
+
+import cython
+
+from libc.stdlib cimport free, malloc
+
+cdef extern from "sys/types.h":
+    ctypedef long off_t
+cdef extern from "sys/sendfile.h":
+    ssize_t sendfile(int out_fd, int in_fd, off_t * offset, size_t count)
+
+def merge_fds(
+    int merged_fd, _component_xyts_files, int merged_nt, int merged_ny, _local_nxs, _local_nys, _y0s
+):
+    cdef int float_size, cur_timestep, cur_component, cur_y, i, y0, local_ny, local_nx, xyts_fd, n_files
+
+    cdef int *component_xyts_files, *local_nxs, *local_nys, *y0s
+
+    n_files = len(_component_xyts_files)
+
+    # The lists _component_xyts_files, ... are CPython lists.
+    # If we access these inside our copying loop everything becomes very slow
+    # because we need to go to the Python interpreter. So we first copy the each
+    # list into an equivalent C list.
+    component_xyts_files = <int *> malloc(len(_component_xyts_files) * cython.sizeof(int))
+    local_nxs = <int *> malloc(len(_local_nxs) * cython.sizeof(int))
+    local_nys = <int *> malloc(len(_local_nys) * cython.sizeof(int))
+    y0s = <int *> malloc(len(_y0s) * cython.sizeof(int))
+    for i in range(len(_component_xyts_files)):
+        component_xyts_files[i] = _component_xyts_files[i]
+        local_nxs[i] = _local_nxs[i]
+        local_nys[i] = _local_nys[i]
+        y0s[i] = _y0s[i]
+
+    for cur_timestep in range(merged_nt):
+        for cur_component in range(3):  # for each component
+            for cur_ in range(merged_ny):
+                for i in range(n_files):
+                    y0 = y0s[i]
+                    local_ny = local_nys[i]
+                    local_nx = local_nxs[i]
+                    xyts_fd = component_xyts_files[i]
+                    if y0 > cur_y or cur_y >= y0 + local_ny:
+                        continue
+                    # By passing None as the offset, sendfile() will read from
+                    # the current position in xyts_fd
+                    sendfile(merged_fd, xyts_fd, NULL, local_nx * 4)
+
+    free(component_xyts_files)
+    free(local_nxs)
+    free(local_nys)
+    free(y0s)

--- a/merge_ts/merge_ts_loop.pyx
+++ b/merge_ts/merge_ts_loop.pyx
@@ -13,7 +13,6 @@ def merge_fds(
     int merged_fd, _component_xyts_files, int merged_nt, int merged_ny, _local_nxs, _local_nys, _y0s
 ):
     cdef int float_size, cur_timestep, cur_component, cur_y, i, y0, local_ny, local_nx, xyts_fd, n_files
-
     cdef int *component_xyts_files, *local_nxs, *local_nys, *y0s
 
     n_files = len(_component_xyts_files)
@@ -31,21 +30,21 @@ def merge_fds(
         local_nxs[i] = _local_nxs[i]
         local_nys[i] = _local_nys[i]
         y0s[i] = _y0s[i]
-
     for cur_timestep in range(merged_nt):
         for cur_component in range(3):  # for each component
-            for cur_ in range(merged_ny):
+            for cur_y in range(merged_ny):
                 for i in range(n_files):
                     y0 = y0s[i]
                     local_ny = local_nys[i]
                     local_nx = local_nxs[i]
                     xyts_fd = component_xyts_files[i]
-                    if y0 > cur_y or cur_y >= y0 + local_ny:
+                    if y0 > cur_y:
+                        break
+                    if cur_y >= y0 + local_ny:
                         continue
                     # By passing None as the offset, sendfile() will read from
                     # the current position in xyts_fd
                     sendfile(merged_fd, xyts_fd, NULL, local_nx * 4)
-
     free(component_xyts_files)
     free(local_nxs)
     free(local_nys)

--- a/merge_ts/setup.py
+++ b/merge_ts/setup.py
@@ -1,4 +1,0 @@
-from Cython.Build import cythonize
-from setuptools import setup
-
-setup(ext_modules=cythonize("merge_ts_loop.pyx"))

--- a/merge_ts/setup.py
+++ b/merge_ts/setup.py
@@ -1,0 +1,4 @@
+from Cython.Build import cythonize
+from setuptools import setup
+
+setup(ext_modules=cythonize("merge_ts_loop.pyx"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cython
 typer
-qcore
-# this is a transient dependency from qcore
-numpy
+git+https://github.com/ucgmsim/qcore
+setuptools
+typer

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ typer
 git+https://github.com/ucgmsim/qcore
 setuptools
 typer
+typing_extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+cython
+typer
+qcore
+# this is a transient dependency from qcore
+numpy

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from Cython.Build import cythonize
+from setuptools import Extension, setup
+
+# Define Cython extension module
+extensions = [Extension("merge_ts.merge_ts_loop", ["merge_ts/merge_ts_loop.pyx"])]
+
+setup(
+    name="merge_ts",
+    version="1.0",
+    packages=["merge_ts"],
+    ext_modules=cythonize(extensions),
+    install_requires=[
+        "cython",
+        "typer",
+        "qcore @ git+https://github.com/ucgmsim/qcore",
+        "setuptools",
+        "typer",
+    ],
+    entry_points={"console_scripts": ["merge_ts=merge_ts.merge_ts:main"]},
+)

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "qcore @ git+https://github.com/ucgmsim/qcore",
         "setuptools",
         "typer",
+        "typing_extensions",
     ],
     entry_points={"console_scripts": ["merge_ts=merge_ts.merge_ts:main"]},
 )


### PR DESCRIPTION
This PR implements merge_ts in python. The speed is as fast as the original C code. It does not suffer the memory problems of the original implementation because it creates no intermediate buffer for the copied values and makes use of the highly efficient `sendfile` kernel syscall to copy data without reading the component xyts files or writing merged xyts file directly. It's set up such that `python setup.py install` installs a `merge_ts` executable to the path so that the following merges all the xyts files in a given directory.

```shell
$ merge_ts *e3d --output merged_xyts.e3d
``` 

Requires ucgmsim/qcore#307